### PR TITLE
use a std::condition_variable instead of usleep

### DIFF
--- a/src/IMPDeviceSource.cpp
+++ b/src/IMPDeviceSource.cpp
@@ -44,13 +44,8 @@ void IMPDeviceSource::deliverFrame0(void *clientData)
 
 H264NALUnit IMPDeviceSource::wait_read()
 {
-    usleep(1000 * 100);
-
-    while (nalQueue.empty())
-    {
-        usleep(1000 * 250);
-        LOG_DDEBUG("wait_read(), nalQueue.empty(), wait for data. " << encChn);
-    }
+    std::unique_lock<std::mutex> lock(queueMutex);
+    queueHasData.wait(lock, [this]{ return !nalQueue.empty(); });
 
     H264NALUnit nal = nalQueue.front();
     nalQueue.pop();
@@ -107,6 +102,7 @@ int IMPDeviceSource::on_data_available(const H264NALUnit &nal)
     }
 
     nalQueue.push(nal);
+    queueHasData.notify_all();
     lock.unlock();
 
     envir().taskScheduler().triggerEvent(eventTriggerId, this);

--- a/src/IMPDeviceSource.cpp
+++ b/src/IMPDeviceSource.cpp
@@ -102,7 +102,10 @@ int IMPDeviceSource::on_data_available(const H264NALUnit &nal)
     }
 
     nalQueue.push(nal);
-    queueHasData.notify_all();
+    if (needNotify)
+    {
+        queueHasData.notify_all();
+    }
     lock.unlock();
 
     envir().taskScheduler().triggerEvent(eventTriggerId, this);

--- a/src/IMPDeviceSource.hpp
+++ b/src/IMPDeviceSource.hpp
@@ -18,6 +18,7 @@ public:
     int encChn;
 
     EventTriggerId eventTriggerId;
+    void initializationComplete() { needNotify = false; }
 
 protected:
     IMPDeviceSource(UsageEnvironment &env, int encChn);
@@ -31,6 +32,7 @@ private:
     std::queue<H264NALUnit> nalQueue;
     std::mutex queueMutex;
     std::condition_variable queueHasData;
+    bool needNotify = true;    // notify is needed only during initialization
 };
 
 #endif

--- a/src/IMPDeviceSource.hpp
+++ b/src/IMPDeviceSource.hpp
@@ -4,6 +4,7 @@
 #include "FramedSource.hh"
 #include "worker.hpp"
 #include <mutex>
+#include <condition_variable>
 #include <queue>
 
 class IMPDeviceSource : public FramedSource
@@ -29,6 +30,7 @@ private:
 
     std::queue<H264NALUnit> nalQueue;
     std::mutex queueMutex;
+    std::condition_variable queueHasData;
 };
 
 #endif

--- a/src/RTSP.cpp
+++ b/src/RTSP.cpp
@@ -59,6 +59,7 @@ void RTSP::addSubsession(int chnNr, _stream &stream)
             // No VPS in H264, so no need to check for it
         }
     }
+    deviceSource->initializationComplete();
     // deviceSource->deinit();
     Worker::remove_sink(chnNr);
     LOG_DEBUG("Got necessary NAL Units.");


### PR DESCRIPTION
This should signal the thread as soon as data was received via the callback.